### PR TITLE
Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ license = "MIT"
 
 [dependencies]
 time = "0.1"
-libc = "0.1"
+libc = "0.2"
 winapi = "0.2"
-kernel32-sys = "0.1"
+kernel32-sys = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,13 @@ impl<I> Iterator for PbIter<I> where
     type Item = I::Item;
 
     fn next(&mut self) -> Option<I::Item> {
-        self.progress_bar.inc();
-        self.iter.next()
+        match self.iter.next() {
+            Some(i) => {
+                self.progress_bar.inc();
+                Some(i)
+            }
+            None => None,
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ impl<I> PbIter<I> where
 {
     pub fn new(iter: I) -> Self {
         let size = iter.size_hint().0;
-        PbIter {iter: iter, progress_bar: ProgressBar::new(size)}
+        PbIter {iter: iter, progress_bar: ProgressBar::new(size as u64)}
     }
 }
 

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -43,8 +43,8 @@ pub enum Units {
 pub struct ProgressBar {
     start_time: Timespec,
     units: Units,
-    total: usize,
-    current: usize,
+    total: u64,
+    current: u64,
     bar_start: String,
     bar_current: String,
     bar_current_n: String,
@@ -76,7 +76,7 @@ impl ProgressBar {
     ///    thread::sleep_ms(100);
     /// }
     /// ```
-    pub fn new(total: usize) -> ProgressBar {
+    pub fn new(total: u64) -> ProgressBar {
         let mut pb = ProgressBar {
             total: total,
             current: 0,
@@ -143,7 +143,7 @@ impl ProgressBar {
     /// pb.add(5);
     /// pb.finish();
     /// ```
-    pub fn add(&mut self, i: usize) -> usize {
+    pub fn add(&mut self, i: u64) -> u64 {
         self.current += i;
         if self.current <= self.total {
             self.draw()
@@ -152,7 +152,7 @@ impl ProgressBar {
     }
 
     /// Increment current value
-    pub fn inc(&mut self) -> usize {
+    pub fn inc(&mut self) -> u64 {
         self.add(1)
     }
 
@@ -254,7 +254,7 @@ impl ProgressBar {
 impl Write for ProgressBar {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let n = buf.len();
-        self.add(n);
+        self.add(n as u64);
         Ok(n)
     }
     fn flush(&mut self) -> io::Result<()> {

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -2,11 +2,6 @@ extern crate libc;
 use super::{Width, Height};
 use std::os::raw::*;
 
-#[cfg(not(target_os = "macos"))]
-const TIOCGWINSZ: c_int = 0x00005413;
-#[cfg(target_os = "macos")]
-const TIOCGWINSZ: c_ulong = 1074295912;
-
 #[derive(Debug)]
 struct WinSize {
     ws_row: c_ushort,
@@ -19,8 +14,7 @@ struct WinSize {
 ///
 /// If STDOUT is not a tty, returns `None`
 pub fn terminal_size() -> Option<(Width, Height)> {
-    use self::libc::{isatty, STDOUT_FILENO};
-    use self::libc::funcs::bsd44::ioctl;
+    use self::libc::{ioctl, isatty, STDOUT_FILENO, TIOCGWINSZ};
     let is_tty: bool = unsafe { isatty(STDOUT_FILENO) == 1 };
 
     if !is_tty {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,7 @@
 extern crate pbr;
 
 use pbr::{ProgressBar, PbIter};
+use std::time::Duration;
 use std::thread;
 
 #[test]
@@ -10,7 +11,7 @@ fn simple_example() {
     pb.format("╢▌▌░╟");
     for _ in 0..count {
         pb.inc();
-        thread::sleep_ms(1);
+        thread::sleep(Duration::from_millis(1));
     }
     println!("done!");
 }
@@ -18,7 +19,7 @@ fn simple_example() {
 #[test]
 fn simple_iter_example(){
     for _ in PbIter::new(0..1000) {
-        thread::sleep_ms(1);
+        thread::sleep(Duration::from_millis(1));
     }
     println!("done!");
 }


### PR DESCRIPTION
This resolves #5, as well as making some other changes. In particular, switching the count type from `usize` to `u64`. A primary use case for this kind of progress bar is for file transfers, and there's no reason it shouldn't be possible to transfer a file larger than 4GB on a 32 bit system.