### PR TITLE
Added message and tick fields in prefix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,19 @@
 //! # Console progress bar for Rust
-//! 
-//! Console progress bar for Rust Inspired from [pb](http://github.com/cheggaaa/pb).  
+//!
+//! Console progress bar for Rust Inspired from [pb](http://github.com/cheggaaa/pb).
 //! support and tested on MacOS and Linux(should work on Windows too, but not tested yet).
-//! 
+//!
 //! ![Screenshot](https://raw.githubusercontent.com/a8m/pb/master/gif/rec.gif)
-//! 
+//!
 //! ### Examples
 //! 1. simple example
-//! 
+//!
 //! ```no_run
 //! extern crate pbr;
-//! 
+//!
 //! use pbr::ProgressBar;
 //! use std::thread;
-//! 
+//!
 //! fn main() {
 //!     let count = 1000;
 //!     let mut pb = ProgressBar::new(count);
@@ -24,18 +24,18 @@
 //!     println!("done!");
 //! }
 //! ```
-//! 
+//!
 //! 2. Broadcast writing(simple file copying)
-//! 
+//!
 //! ```ignore
 //! #![feature(io)]
 //! extern crate pbr;
-//! 
+//!
 //! use std::io::copy;
 //! use std::io::prelude::*;
 //! use std::fs::File;
 //! use pbr::{ProgressBar, Units};
-//! 
+//!
 //! fn main() {
 //!     let mut file = File::open("/usr/share/dict/words").unwrap();
 //!     let n_bytes = file.metadata().unwrap().len() as usize;
@@ -52,24 +52,27 @@ mod pb;
 pub use pb::{ProgressBar, Units};
 
 
-pub struct PbIter<I> where
-    I: Iterator,
+pub struct PbIter<I>
+    where I: Iterator
 {
     iter: I,
     progress_bar: ProgressBar,
 }
 
-impl<I> PbIter<I> where
-    I: Iterator
+impl<I> PbIter<I>
+    where I: Iterator
 {
     pub fn new(iter: I) -> Self {
         let size = iter.size_hint().0;
-        PbIter {iter: iter, progress_bar: ProgressBar::new(size as u64)}
+        PbIter {
+            iter: iter,
+            progress_bar: ProgressBar::new(size as u64),
+        }
     }
 }
 
-impl<I> Iterator for PbIter<I> where
-    I: Iterator
+impl<I> Iterator for PbIter<I>
+    where I: Iterator
 {
     type Item = I::Item;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -23,3 +23,59 @@ fn simple_iter_example(){
     }
     println!("done!");
 }
+
+#[test]
+fn timeout_example() {
+    let count = 100;
+    let mut pb = ProgressBar::new(count*20);
+    pb.tick_format("▏▎▍▌▋▊▉██▉▊▋▌▍▎▏");
+    pb.show_message = true;
+    pb.inc();
+    for _ in 0..count {
+        for _ in 0..20 {
+            pb.message("Waiting  : ");
+            thread::sleep(Duration::from_millis(50));
+            pb.tick();
+        }
+        for _ in 0..20 {
+            pb.message("Connected: ");
+            thread::sleep(Duration::from_millis(50));
+            pb.inc();   
+        }
+    }
+    for _ in 0..10 {
+        pb.message("Cleaning :");
+        thread::sleep(Duration::from_millis(50));
+        pb.tick();
+    }
+    pb.finish();
+    println!("done!");
+}
+
+#[test]
+fn npm_bar() {
+   let count = 20;
+    let mut pb = ProgressBar::new(count*5);
+    pb.tick_format("\\|/-");
+    pb.format("|#--|");
+    pb.show_tick = true;
+    pb.show_speed = false;
+    pb.show_percent = false;
+    pb.show_counter = false;
+    pb.show_time_left = false;
+    pb.inc();
+    for _ in 0..count {
+        for _ in 0..5 {
+            pb.message("normalize -> thing ");
+            thread::sleep(Duration::from_millis(80));
+            pb.tick();
+        }
+        for _ in 0..5 {
+            pb.message("fuzz -> tree       ");
+            thread::sleep(Duration::from_millis(80));
+            pb.inc();   
+        }
+    }
+    pb.finish();
+    println!("done!");
+}


### PR DESCRIPTION
* Added **tick** field to prefix:
    - Char field that looks like a loading symbol ; useful to show ProgressBar is still being updated even though no progress are made.
    - ** speed ** field looks odd when the bar is being updated with **tick**, so best option right now is to disable it (maybe later the speed calculation could take place in _**add**_ instead of __**draw**__, so that only progress would result in speed calculation).
    - Calling _pb.tick_ on a bar with 0 progress will result in a panic (_division by zero_), so be sure to have called _pb.inc()_ **at least once** before using _pb.tick()_


* Added **message** field to prefix:
    - message can be changed by calling _pb.message("smthng")_
    - message field will disappear when calling _pb("")_.
    - message of same length should be used when frequently updating message, or it will result in a flickering of the ProgressBar"s bar field.


Both those options **require** the user to call an init instruction of the lib to be displayed, so code using old versions of **pb** should display their ProgressBar as before without error.


To use tick : 
```rust
// with default tick format: \|/-
let pb = ProgressBar::new(...);
pb.show_tick = true;
...
pb.inc() 
...
pb.tick()
```
or
```rust
// with custom tick format:
let pb = ProgressBar::new(...);
pb.tick_format(">^<v");
...
```

To use message:
```rust
let pb = ProgressBar::new();
pb.message("msg");
...
```

which means a ```ProgressBar::new()``` object will neither have a message field nor a tick field.


A quick view of the new features (both are contained in test/lib.rs): 
a bar looking like npm install bar : https://asciinema.org/a/87m1dx8hgs43rmbos8kl52juk
an example of command with wait time between progress : https://asciinema.org/a/5iqwcbai6rchk2sb3ropfvev9
