### PR TITLE
Arbitrary writer + Fix #15

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,30 +50,37 @@ extern crate time;
 mod tty;
 mod pb;
 pub use pb::{ProgressBar, Units};
-use std::io::Write;
+use std::io::{Write, Stdout, stdout};
 
 pub struct PbIter<T, I>
-    where I: Iterator,
-          T: Write
+where I: Iterator,
+      T: Write
 {
     iter: I,
     progress_bar: ProgressBar<T>,
 }
 
-impl<T, I> PbIter<T, I>
-    where I: Iterator,
-          T: Write
+impl<I> PbIter<Stdout, I>
+where I: Iterator
 {
-    pub fn new(handle: T, iter: I) -> Self {
+    pub fn new(iter: I) -> Self {
+        Self::on(stdout(), iter)
+    }
+}
+
+impl<T, I> PbIter<T, I>
+where I: Iterator,
+      T: Write
+{
+    pub fn on(handle: T, iter: I) -> Self {
         let size = iter.size_hint().0;
-        let pb: PbIter<T, I> = PbIter {iter: iter, progress_bar: ProgressBar::new(handle, size as u64)};
-        pb
+        PbIter {iter: iter, progress_bar: ProgressBar::on(handle, size as u64)}
     }
 }
 
 impl<T, I> Iterator for PbIter<T, I>
-    where I: Iterator,
-    T: Write
+where I: Iterator,
+      T: Write
 {
     type Item = I::Item;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,29 +50,30 @@ extern crate time;
 mod tty;
 mod pb;
 pub use pb::{ProgressBar, Units};
+use std::io::Write;
 
-
-pub struct PbIter<I>
-    where I: Iterator
+pub struct PbIter<T, I>
+    where I: Iterator,
+          T: Write
 {
     iter: I,
-    progress_bar: ProgressBar,
+    progress_bar: ProgressBar<T>,
 }
 
-impl<I> PbIter<I>
-    where I: Iterator
+impl<T, I> PbIter<T, I>
+    where I: Iterator,
+          T: Write
 {
-    pub fn new(iter: I) -> Self {
+    pub fn new(handle: T, iter: I) -> Self {
         let size = iter.size_hint().0;
-        PbIter {
-            iter: iter,
-            progress_bar: ProgressBar::new(size as u64),
-        }
+        let pb: PbIter<T, I> = PbIter {iter: iter, progress_bar: ProgressBar::new(handle, size as u64)};
+        pb
     }
 }
 
-impl<I> Iterator for PbIter<I>
-    where I: Iterator
+impl<T, I> Iterator for PbIter<T, I>
+    where I: Iterator,
+    T: Write
 {
     type Item = I::Item;
 

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -69,7 +69,6 @@ pub struct ProgressBar<T: Write> {
 }
 
 impl ProgressBar<Stdout> {
-
     /// Create a new ProgressBar with default configuration.
     ///
     /// # Examples
@@ -94,7 +93,6 @@ impl ProgressBar<Stdout> {
 }
 
 impl<T: Write> ProgressBar<T> {
-
     /// Create a new ProgressBar with default configuration but
     /// pass an arbitrary writer.
     ///
@@ -329,15 +327,17 @@ impl<T: Write> ProgressBar<T> {
                 if size > 0 {
                     let curr_count = ((self.current as f64 / self.total as f64) * size as f64)
                         .ceil() as usize;
-                    let rema_count = size - curr_count;
-                    base = self.bar_start.clone();
-                    if rema_count > 0 && curr_count > 0 {
-                        base = base + repeat!(self.bar_current.as_ref(), curr_count - 1) +
-                               &self.bar_current_n;
-                    } else {
-                        base = base + repeat!(self.bar_current.as_ref(), curr_count);
+                    if size > curr_count {
+                        let rema_count = size - curr_count;
+                        base = self.bar_start.clone();
+                        if rema_count > 0 && curr_count > 0 {
+                            base = base + repeat!(self.bar_current.as_ref(), curr_count - 1) +
+                                   &self.bar_current_n;
+                        } else {
+                            base = base + repeat!(self.bar_current.as_ref(), curr_count);
+                        }
+                        base = base + repeat!(self.bar_remain.as_ref(), rema_count) + &self.bar_end;
                     }
-                    base = base + repeat!(self.bar_remain.as_ref(), rema_count) + &self.bar_end;
                 }
             }
         }

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -46,7 +46,7 @@ pub enum Units {
 pub struct ProgressBar<T: Write> {
     start_time: SteadyTime,
     units: Units,
-    total: u64,
+    pub total: u64,
     current: u64,
     bar_start: String,
     bar_current: String,
@@ -301,19 +301,22 @@ impl<T: Write> ProgressBar<T> {
         }
         // bar box
         if self.show_bar {
-            let size = width - (prefix.len() + suffix.len() + 3);
-            if size > 0 {
-                let curr_count = ((self.current as f64 / self.total as f64) * size as f64)
-                    .ceil() as usize;
-                let rema_count = size - curr_count;
-                base = self.bar_start.clone();
-                if rema_count > 0 && curr_count > 0 {
-                    base = base + repeat!(self.bar_current.as_ref(), curr_count - 1) +
-                           &self.bar_current_n;
-                } else {
-                    base = base + repeat!(self.bar_current.as_ref(), curr_count);
+            let p = prefix.len() + suffix.len() + 3;
+            if p <= width {
+                let size = width - p;
+                if size > 0 {
+                    let curr_count = ((self.current as f64 / self.total as f64) * size as f64)
+                        .ceil() as usize;
+                    let rema_count = size - curr_count;
+                    base = self.bar_start.clone();
+                    if rema_count > 0 && curr_count > 0 {
+                        base = base + repeat!(self.bar_current.as_ref(), curr_count - 1) +
+                               &self.bar_current_n;
+                    } else {
+                        base = base + repeat!(self.bar_current.as_ref(), curr_count);
+                    }
+                    base = base + repeat!(self.bar_remain.as_ref(), rema_count) + &self.bar_end;
                 }
-                base = base + repeat!(self.bar_remain.as_ref(), rema_count) + &self.bar_end;
             }
         }
         out = prefix + &base + &suffix;

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -68,7 +68,8 @@ pub struct ProgressBar<T: Write> {
     handle: T,
 }
 
-impl<T: Write> ProgressBar<T> {
+impl ProgressBar<Stdout> {
+
     /// Create a new ProgressBar with default configuration.
     ///
     /// # Examples
@@ -86,13 +87,34 @@ impl<T: Write> ProgressBar<T> {
     ///    thread::sleep_ms(100);
     /// }
     /// ```
-    pub fn stdout(total: u64) -> ProgressBar<Stdout> {
+    pub fn new(total: u64) -> ProgressBar<Stdout> {
         let handle = ::std::io::stdout();
-        let pb = ProgressBar::new(handle, total);
-        pb
+        ProgressBar::on(handle, total)
     }
+}
 
-    pub fn new(handle: T, total: u64) -> ProgressBar<T> {
+impl<T: Write> ProgressBar<T> {
+
+    /// Create a new ProgressBar with default configuration but
+    /// pass an arbitrary writer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::thread;
+    /// use std::io::stderr;
+    /// use pbr::{ProgressBar, Units};
+    ///
+    /// let count = 1000;
+    /// let mut pb = ProgressBar::on(stderr(), count);
+    /// pb.set_units(Units::Bytes);
+    ///
+    /// for _ in 0..count {
+    ///    pb.inc();
+    ///    thread::sleep_ms(100);
+    /// }
+    /// ```
+    pub fn on(handle: T, total: u64) -> ProgressBar<T> {
         let mut pb = ProgressBar {
             total: total,
             current: 0,


### PR DESCRIPTION
- Added support for passing an arbitrary `Write` object instead of stdout. I think It makes it more testable and I don't see why it shouldn't be possible. I needed to print to stderr, for example.
- Fixes #15
- Exposed `total` field

I need it to happen for a project of mine. I understand it might not be exactly what you want so I'm open to discussing changes or removing the PR.

