### PR TITLE
Add logging support for ProgressBar and MultiBar

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,13 @@ macro_rules! printfl {
     }}
 }
 
+macro_rules! repeat {
+    ($s: expr, $n: expr) => {{
+        &repeat($s).take($n).collect::<String>()
+    }}
+}
+
+
 #[macro_use]
 extern crate time;
 mod tty;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ macro_rules! repeat {
     }}
 }
 
+const PBR_LOG_BOUNDARY: &'static str = "--PBR-LOG-BOUNDARY";
 
 #[macro_use]
 extern crate time;

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -18,12 +18,6 @@ macro_rules! kb_fmt {
     }}
 }
 
-macro_rules! repeat {
-    ($s: expr, $n: expr) => {{
-        &repeat($s).take($n).collect::<String>()
-    }}
-}
-
 const FORMAT: &'static str = "[=>-]";
 const TICK_FORMAT: &'static str = "\\|/-";
 const NANOS_PER_SEC: u32 = 1_000_000_000;


### PR DESCRIPTION
Hello :)

I have added simple logging support to ProgressBar and MultiBar, hopefully in a way that doesn't cause issues for anyone who doesn't need it. 

Log messages are printed above the bar area and appear to move upward with each new log message, as you would expect.

To allow ProgressBar to log messages when part of a MultiBar without significantly changing the way they are implemented, I have borrowed a trick from HTTP multipart/form-data and added an optional boundary string to Pipe.

If that boundary string is included in a string sent across the Pipe to MultiBar, the string is split and the first section is treated as a log message, the second is the bar string. If no boundary is sent, it should operate exactly the same as it did before.

I considered adding support for integration with the `log` crate, formatting, colors, and a way to present a virtual "log window" where the messages disappear at the top rather than continuing to scroll, but this seemed like a good start and those can be added later if necessary.

All the existing tests pass, though some of the failing doc tests look like they were never intended to pass (missing variables).