### PR TITLE
Fix for DragonFly and FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["cli", "progress", "terminal", "pb"]
 license = "MIT"
 
 [dependencies]
-libc = "0.2.9"
+libc = "0.2"
 time = "0.1.35"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
TIOCGWINSZ is defined in libc as c_int, but ioctl() expects
an c_ulong.