### PR TITLE
Use the SI binary notation for formatted bytes

### DIFF
--- a/src/pb.rs
+++ b/src/pb.rs
@@ -9,10 +9,10 @@ macro_rules! kb_fmt {
     ($n: ident) => {{
         let kb = 1024f64;
         match $n {
-            $n if $n >= kb.powf(4_f64) => format!("{:.*} TB", 2, $n / kb.powf(4_f64)),
-            $n if $n >= kb.powf(3_f64) => format!("{:.*} GB", 2, $n / kb.powf(3_f64)),
-            $n if $n >= kb.powf(2_f64) => format!("{:.*} MB", 2, $n / kb.powf(2_f64)),
-            $n if $n >= kb => format!("{:.*} KB", 2, $n / kb),
+            $n if $n >= kb.powf(4_f64) => format!("{:.*} TiB", 2, $n / kb.powf(4_f64)),
+            $n if $n >= kb.powf(3_f64) => format!("{:.*} GiB", 2, $n / kb.powf(3_f64)),
+            $n if $n >= kb.powf(2_f64) => format!("{:.*} MiB", 2, $n / kb.powf(2_f64)),
+            $n if $n >= kb => format!("{:.*} KiB", 2, $n / kb),
             _ => format!("{:.*} B", 0, $n)
         }
     }}


### PR DESCRIPTION
This (fairly small) pull request modifies the byte notation slightly, to follow the international SI standard. It changes the `KB` notation to a better defined `KiB` notation, as we're working with a binary (1024 based) notation.

SE standard: https://physics.nist.gov/cuu/Units/binary.html