### PR TITLE
Update winapi to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ license = "MIT"
 libc = "0.2"
 time = "0.1.35"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
+[target.'cfg(target_os = "windows")'.dependencies.winapi]
+version = "0.3"
+features = ["wincon", "processenv", "winbase"]
 
 [target.'cfg(target_os = "redox")'.dependencies]
 termion = "1.4"

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -1,5 +1,4 @@
 extern crate winapi;
-extern crate kernel32;
 
 use super::{Width, Height};
 
@@ -20,8 +19,7 @@ pub fn terminal_size() -> Option<(Width, Height)> {
 /// move the cursor `n` lines up; return an empty string, just to
 /// be aligned with the unix version.
 pub fn move_cursor_up(n: usize) -> String {
-    use self::kernel32::SetConsoleCursorPosition;
-    use self::winapi::COORD;
+    use self::winapi::um::wincon::{SetConsoleCursorPosition, COORD};
     if let Some((hand, csbi)) = get_csbi() {
         unsafe {
             SetConsoleCursorPosition(hand,
@@ -34,11 +32,11 @@ pub fn move_cursor_up(n: usize) -> String {
     "".to_string()
 }
 
-fn get_csbi() -> Option<(self::winapi::HANDLE, self::winapi::CONSOLE_SCREEN_BUFFER_INFO)> {
-    use self::winapi::HANDLE;
-    use self::kernel32::{GetStdHandle, GetConsoleScreenBufferInfo};
-    use self::winapi::STD_OUTPUT_HANDLE;
-    use self::winapi::{CONSOLE_SCREEN_BUFFER_INFO, COORD, SMALL_RECT};
+fn get_csbi() -> Option<(self::winapi::shared::ntdef::HANDLE, self::winapi::um::wincon::CONSOLE_SCREEN_BUFFER_INFO)> {
+    use self::winapi::shared::ntdef::HANDLE;
+    use self::winapi::um::processenv::GetStdHandle;
+    use self::winapi::um::winbase::STD_OUTPUT_HANDLE;
+    use self::winapi::um::wincon::{GetConsoleScreenBufferInfo, CONSOLE_SCREEN_BUFFER_INFO, COORD, SMALL_RECT};
 
     let hand: HANDLE = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
 


### PR DESCRIPTION
This updates the winapi crate to 0.3, which re-organizes its modules and
removes the need for kernal32-sys. More and more crates are using v0.3,
and this allows better reuse in larger dependency graphs.

The other notable change is winapi's heavy use of features to cull sub modules. This will only matter when using more winapi functions.
See `winapi`'s README for details.

> 
> ### Why am I getting errors about unresolved imports?
> 
> Each module is gated on a feature flag, so you must enable the appropriate feature to gain access to those items. For example, if you want to use something from `winapi::um::winuser` you must enable the `winuser` feature.
> 

I've been using this crate in a couple small projects, and having two winapi versions in the dependency graph very quickly handicaps `cargo doc` build times.

## Testing
- I ran `cargo test` on Windows 10 and Linux through the WSL and everything worked fine.
- I ran the examples and they look fine.
- I ran my own application using the Multibar with the updated `pb` crate on Windows 10 without issue.