### PR TITLE
Add flush and graduate to MultiBar

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ mod tty;
 mod pb;
 mod multi;
 pub use pb::{ProgressBar, Units};
-pub use multi::{MultiBar, Pipe};
+pub use multi::{MultiBar, Pipe, FinishMethod};
 use std::io::{Write, Stdout, stdout};
 
 pub struct PbIter<T, I>


### PR DESCRIPTION
1. add non-blocking `flush` method
2. add `set_finish` to set behavior when a ProgressBar is finished
   * Keep: the current behavior, keep the progress bar in line
   * Remove: remove the progress bar in self.lines, reduce self.nlines by 1
   * Graduate: like Remove, but print the finished progress bar above the MultiBar (wouldn't update anymore)