### PR TITLE
Exclude non-source files from crate, making it smaller

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Ariel Mashraki <ariel@mashraki.co.il>", "Steven Fackler <sfackler@gm
 description = "Console progress bar for Rust"
 documentation = "http://a8m.github.io/pb/doc/pbr/index.html"
 repository = "https://github.com/a8m/pb"
+exclude = ["gif/", ".travis.yml"]
 keywords = ["cli", "progress", "terminal", "pb"]
 license = "MIT"
 


### PR DESCRIPTION
Fixes #89 