### PR TITLE
Add elementary wasi support

### DIFF
--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -17,6 +17,11 @@ mod unix;
 #[cfg(unix)]
 pub use self::unix::*;
 
+#[cfg(target_os="wasi")]
+mod wasi;
+#[cfg(target_os="wasi")]
+pub use self::wasi::*;
+
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]

--- a/src/tty/wasi.rs
+++ b/src/tty/wasi.rs
@@ -1,0 +1,16 @@
+extern crate libc;
+use super::{Width, Height};
+
+/// For WASI so far it will return none
+///
+/// For background https://github.com/WebAssembly/WASI/issues/42
+pub fn terminal_size() -> Option<(Width, Height)> {
+    return None;
+}
+
+/// This is inherited from unix and will work only when wasi executed on unix.
+/// 
+/// For background https://github.com/WebAssembly/WASI/issues/42
+pub fn move_cursor_up(n: usize) -> String {
+    format!("\x1B[{}A", n)
+}


### PR DESCRIPTION
Pbr is referenced from many crates and provides really cool reporting capabilities. Though at the moment compiling to wasm32-wasi is failing, nevertheless it provides elementary stdout capabilities. 

This PR adds wasi target support allowing to compile dependant crates, but also inheriting cursor control from unix which is most common deployment platform for terminal-like software. On other terminals it will still work, though not so nice until good tty support is added to WASI core spec, here is discussion in the past about the topic https://github.com/WebAssembly/WASI/issues/42