### PR TITLE
feat: MultiBar is now thread-safe; Create new bars dynamically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,15 @@ license = "MIT"
 
 [dependencies]
 libc = "0.2"
-time = "0.1.35"
+time = "0.1"
+crossbeam-channel = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3"
 features = ["wincon", "processenv", "winbase"]
 
 [target.'cfg(target_os = "redox")'.dependencies]
-termion = "1.4"
+termion = "1.5"
 
 [dev-dependencies]
-rand = "0.5"
+rand = "0.7"

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let mut mb = MultiBar::new();
+    let mb = MultiBar::new();
     mb.println("Your Application Header:");
     mb.println("");
 

--- a/examples/multi_bg.rs
+++ b/examples/multi_bg.rs
@@ -1,0 +1,47 @@
+extern crate pbr;
+
+use pbr::MultiBar;
+use std::{
+    sync::{atomic::{AtomicBool, Ordering}, Arc},
+    thread,
+    time::Duration,
+};
+
+fn main() {
+    let complete = Arc::new(AtomicBool::new(false));
+    let progress = Arc::new(MultiBar::new());
+
+    thread::spawn({
+        let complete = Arc::clone(&complete);
+        let progress = Arc::clone(&progress);
+        move || {
+            for task in 1..=10 {
+                thread::spawn({
+                    let progress = Arc::clone(&progress);
+                    move || {
+                        let mut bar = progress.create_bar(100);
+                        bar.message(&format!("Task {}: ", task));
+
+                        for _ in 0..100 {
+                            thread::sleep(Duration::from_millis(50));
+                            bar.inc();
+                        } 
+
+                        bar.finish_print(&format!("Task {} Complete", task));
+                    }
+                });
+
+                thread::sleep(Duration::from_millis(1000));
+            }
+
+            complete.store(true, Ordering::SeqCst);
+        }
+    });
+
+    while !complete.load(Ordering::SeqCst) {
+        let _ = progress.listen();
+        thread::sleep(Duration::from_millis(1000));
+    }
+
+    let _ = progress.listen();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ macro_rules! printfl {
     }}
 }
 
+extern crate crossbeam_channel;
 extern crate time;
 mod multi;
 mod pb;


### PR DESCRIPTION
Allows the creation of new progress bars while the `MultiBar` is already listening.

By wrapping a `MultiBar` in an `Arc`, it can be safely shared and used across threads.

Closes #35 
Closes #87