### PR TITLE
Added reset_start_time

### DIFF
--- a/src/pb.rs
+++ b/src/pb.rs
@@ -311,8 +311,6 @@ impl<T: Write> ProgressBar<T> {
     }
 
     /// Resets the start time to now
-    ///
-    /// This allows you to set up the bar some time before it is needed and have the speed and time indications be correct
     pub fn reset_start_time(&mut self) {
         self.start_time = SteadyTime::now();
     }

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -310,6 +310,9 @@ impl<T: Write> ProgressBar<T> {
         self.add(1)
     }
 
+    /// Resets the start time to now
+    ///
+    /// This allows you to set up the bar some time before it is needed and have the speed and time indications be correct
     pub fn reset_start_time(&mut self) {
         self.start_time = SteadyTime::now();
     }

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -310,6 +310,10 @@ impl<T: Write> ProgressBar<T> {
         self.add(1)
     }
 
+    pub fn reset_start_time(&mut self) {
+        self.start_time = SteadyTime::now();
+    }
+    
     fn draw(&mut self) {
         let now = SteadyTime::now();
         if let Some(mrr) = self.max_refresh_rate {


### PR DESCRIPTION
This allows for creating a bar, but start using it later and have the time estimations be correct.