### PR TITLE
Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pbr"
 version = "1.0.3"
 authors = ["Ariel Mashraki <ariel@mashraki.co.il>", "Steven Fackler <sfackler@gmail.com>"]
+edition = "2018"
 description = "Console progress bar for Rust"
 documentation = "http://a8m.github.io/pb/doc/pbr/index.html"
 repository = "https://github.com/a8m/pb"

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1,10 +1,10 @@
-use crossbeam_channel::{unbounded, Sender, Receiver};
-use pb::ProgressBar;
+use crate::tty::move_cursor_up;
+use crate::ProgressBar;
+use crossbeam_channel::{unbounded, Receiver, Sender};
 use std::io::{Result, Stdout, Write};
 use std::str::from_utf8;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tty::move_cursor_up;
+use std::sync::Mutex;
 
 pub struct MultiBar<T: Write> {
     state: Mutex<State<T>>,
@@ -15,7 +15,7 @@ pub struct MultiBar<T: Write> {
 struct State<T: Write> {
     lines: Vec<String>,
     nlines: usize,
-    handle: T
+    handle: T,
 }
 
 impl MultiBar<Stdout> {
@@ -156,7 +156,7 @@ impl<T: Write> MultiBar<T> {
     /// ```
     pub fn create_bar(&self, total: u64) -> ProgressBar<Pipe> {
         let mut state = self.state.lock().unwrap();
-        
+
         state.lines.push(String::new());
         state.nlines += 1;
 
@@ -169,7 +169,7 @@ impl<T: Write> MultiBar<T> {
             },
             total,
         );
-        
+
         p.is_multibar = true;
         p.add(0);
         p

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -1,9 +1,9 @@
+use crate::tty::{terminal_size, Width};
 use std::io::Stdout;
 use std::io::{self, Write};
 use std::iter::repeat;
 use std::time::Duration;
 use time::{self, SteadyTime};
-use tty::{terminal_size, Width};
 
 macro_rules! kb_fmt {
     ($n: ident) => {{
@@ -314,7 +314,7 @@ impl<T: Write> ProgressBar<T> {
     pub fn reset_start_time(&mut self) {
         self.start_time = SteadyTime::now();
     }
-    
+
     fn draw(&mut self) {
         let now = SteadyTime::now();
         if let Some(mrr) = self.max_refresh_rate {
@@ -507,7 +507,7 @@ fn fract_dur(d: Duration) -> f64 {
 
 #[cfg(test)]
 mod test {
-    use pb::{ProgressBar, Units};
+    use crate::{ProgressBar, Units};
     use std::time::Duration;
 
     #[test]
@@ -636,15 +636,11 @@ mod test {
             .split('\r');
         assert_eq!(
             split.next(),
-            Some(
-                "250 / 500 ╢▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌░░░░░░░░░░░░░░░░░░░░░░░░░░░░░╟ 50.00 %"
-            )
+            Some("250 / 500 ╢▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌░░░░░░░░░░░░░░░░░░░░░░░░░░░░░╟ 50.00 %")
         );
         assert_eq!(
             split.next(),
-            Some(
-                "500 / 500 ╢▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌╟ 100.00 %"
-            )
+            Some("500 / 500 ╢▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌╟ 100.00 %")
         );
     }
 }


### PR DESCRIPTION
This PR updates `pbr` to follow Rust 2018 conventions, particularly with regards to imports.
