### PR TITLE
Change documentation link to doc.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest version](https://img.shields.io/crates/v/pbr.svg)](https://crates.io/crates/pbr)
 [![License](https://img.shields.io/crates/l/pbr.svg)](https://github.com/a8m/pb/blob/master/LICENSE.md)
-[![Docs](https://img.shields.io/badge/docs-reference-blue.svg)](https://a8m.github.io/pb/doc/pbr/index.html)
+[![Docs](https://img.shields.io/badge/docs-reference-blue.svg)](https://docs.rs/pbr/latest/pbr/index.html)
 [![Build Status](https://travis-ci.org/a8m/pb.svg?branch=master)](https://travis-ci.org/a8m/pb)
 [![Gitter](https://badges.gitter.im/a8m/pb.svg)](https://gitter.im/a8m/pb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
The documentation on github.io seems to be significantly outdated and may lead to confusions (for example, almost all APIs in (this page)[https://a8m.github.io/pb/doc/pbr/struct.MultiBar.html] is redesigned). Therefore, pointing the documentation to doc.rs should be a good idea since they'll automatically update the documentation version according to the version uploaded to crates.io.