### PR TITLE
Drop dependency on `time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT"
 
 [dependencies]
 libc = "0.2"
-time = "0.1"
 crossbeam-channel = "0.5"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,6 @@ macro_rules! printfl {
 }
 
 extern crate crossbeam_channel;
-extern crate time;
 mod multi;
 mod pb;
 mod tty;


### PR DESCRIPTION
pbr currently depends on version 0.1 of time which is was found to contain a security vulnerability
(RUSTSEC-2020-0071 [1]). Updating to the current 0.3 branch would be a possiblity, however that
doesn't gain us anything over just relying on std. SteadyTime no longer exists and was never
actually steady in the first place [2]. For a while there was a fallback that turned SteadyTime
into an alias for time::Instant [3] which in turn is a wrapper around std::time::Instant adding
support for negative durations.

pbr doesn't deal with negative durations so swap time::Duration for std::time::Duration and
time::SteadyTime for std::time::Instant.

[1] https://rustsec.org/advisories/RUSTSEC-2020-0071
[2] https://github.com/time-rs/time/issues/95
[3] https://github.com/time-rs/time/commit/76e35751dd8fea01e75a6c5c14fb9a6a044787ad