### PR TITLE
Remove `extern crate` lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ tested on MacOS, Linux and Windows
 1. simple example
 
 ```rust
-extern crate pbr;
-
 use pbr::ProgressBar;
 use std::thread;
 
@@ -36,8 +34,6 @@ fn main() {
 
 2. MultiBar example. see full example [here](https://github.com/a8m/pb/blob/master/examples/multi.rs)
 ```rust
-extern crate pbr;
-
 use std::thread;
 use pbr::MultiBar;
 use std::time::Duration;
@@ -80,8 +76,6 @@ fn main() {
 
 ```rust
 #![feature(io)]
-extern crate pbr;
-
 use std::io::copy;
 use std::io::prelude::*;
 use std::fs::File;

--- a/examples/max_refresh_rate.rs
+++ b/examples/max_refresh_rate.rs
@@ -1,4 +1,3 @@
-extern crate pbr;
 use pbr::ProgressBar;
 use std::thread;
 use std::time::Duration;

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -1,5 +1,3 @@
-extern crate pbr;
-extern crate rand;
 use pbr::MultiBar;
 use rand::prelude::*;
 use std::thread;

--- a/examples/multi_bg.rs
+++ b/examples/multi_bg.rs
@@ -1,5 +1,3 @@
-extern crate pbr;
-
 use pbr::MultiBar;
 use std::{
     sync::{atomic::{AtomicBool, Ordering}, Arc},

--- a/examples/npm_bar.rs
+++ b/examples/npm_bar.rs
@@ -1,4 +1,3 @@
-extern crate pbr;
 use pbr::ProgressBar;
 use std::thread;
 use std::time::Duration;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,3 @@
-extern crate pbr;
-extern crate rand;
 use pbr::ProgressBar;
 use rand::prelude::*;
 use std::thread;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,6 @@
 //! 1. simple example
 //!
 //! ```ignore
-//! extern crate pbr;
-//!
 //! use pbr::ProgressBar;
 //! use std::thread;
 //!
@@ -31,8 +29,6 @@
 //! 2. MultiBar example. see full example [here](https://github.com/a8m/pb/blob/master/examples/multi.rs)
 //!
 //! ```ignore
-//! extern crate pbr;
-//!
 //! use std::thread;
 //! use pbr::MultiBar;
 //! use std::time::Duration;
@@ -75,8 +71,6 @@
 //!
 //! ```ignore
 //! #![feature(io)]
-//! extern crate pbr;
-//!
 //! use std::io::copy;
 //! use std::io::prelude::*;
 //! use std::fs::File;
@@ -111,7 +105,6 @@ macro_rules! printfl {
     }}
 }
 
-extern crate crossbeam_channel;
 mod multi;
 mod pb;
 mod tty;

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 use super::{Height, Width};
 
 // We need to convert from c_int to c_ulong at least on DragonFly and FreeBSD.
@@ -17,7 +16,7 @@ fn ioctl_conv<T: Copy>(v: T) -> T {
 ///
 /// If STDOUT is not a tty, returns `None`
 pub fn terminal_size() -> Option<(Width, Height)> {
-    use self::libc::{ioctl, isatty, winsize, STDOUT_FILENO, TIOCGWINSZ};
+    use libc::{ioctl, isatty, winsize, STDOUT_FILENO, TIOCGWINSZ};
     let is_tty: bool = unsafe { isatty(STDOUT_FILENO) == 1 };
 
     if !is_tty {

--- a/src/tty/wasi.rs
+++ b/src/tty/wasi.rs
@@ -1,4 +1,3 @@
-extern crate libc;
 use super::{Width, Height};
 
 /// For WASI so far it will return none

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -1,5 +1,3 @@
-extern crate winapi;
-
 use super::{Height, Width};
 
 /// Returns the size of the terminal, if available.


### PR DESCRIPTION
They have been mostly phased out with Rust 2018.