### PR TITLE
Avoid copying the message three times in ProgressBar::message

### DIFF
--- a/src/pb.rs
+++ b/src/pb.rs
@@ -194,7 +194,7 @@ impl<T: Write> ProgressBar<T> {
     ///
     /// ```
     pub fn message(&mut self, message: &str) {
-        self.message = message.to_owned().replace("\n", " ").replace("\r", " ")
+        self.message = message.replace(['\n', '\r'], " ")
     }
 
     /// Set tick format for the progressBar, default is \\|/-


### PR DESCRIPTION
String::replace doesn't modify the original String, so `to_owned` can be dropped. It also accepts
&[char] as a pattern and replaces any of the chars found. The two calls to `replace` can thus be
combined into one.

This brings us from three copies with two scan passes down to one copy with one scan pass.