### PR TITLE
Ensure all output gets written

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@
 // ```
 macro_rules! printfl {
    ($w:expr, $($tt:tt)*) => {{
-        $w.write(&format!($($tt)*).as_bytes()).ok().expect("write() fail");
+        $w.write_all(&format!($($tt)*).as_bytes()).ok().expect("write() fail");
         $w.flush().ok().expect("flush() fail");
     }}
 }


### PR DESCRIPTION
Writer::write does NOT guarantee that all bytes in the buffer get written. Writer::write_all needs
to be used for that.

Spotted by clippy