### PR TITLE
Fix clippy warnings: constants have by default a 'static lifetime

### DIFF
--- a/src/pb.rs
+++ b/src/pb.rs
@@ -16,8 +16,8 @@ macro_rules! kb_fmt {
     }};
 }
 
-const FORMAT: &'static str = "[=>-]";
-const TICK_FORMAT: &'static str = "\\|/-";
+const FORMAT: &str = "[=>-]";
+const TICK_FORMAT: &str = "\\|/-";
 
 // Output type format, indicate which format wil be used in
 // the speed box.


### PR DESCRIPTION
```
warning: constants have by default a `'static` lifetime
  --> src/pb.rs:19:16
   |
19 | const FORMAT: &'static str = "[=>-]";
   |               -^^^^^^^---- help: consider removing `'static`: `&str`
   |
   = note: `#[warn(clippy::redundant_static_lifetimes)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes

warning: constants have by default a `'static` lifetime
  --> src/pb.rs:20:21
   |
20 | const TICK_FORMAT: &'static str = "\\|/-";
   |                    -^^^^^^^---- help: consider removing `'static`: `&str`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes
```