### PR TITLE
Fix clippy warnings: comparison to empty slice

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -246,7 +246,7 @@ impl Write for Pipe {
         self.chan
             .send(WriteMsg {
                 // finish method emit empty string
-                done: s == "",
+                done: s.is_empty(),
                 level: self.level,
                 string: s,
             })

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -208,7 +208,7 @@ impl<T: Write> ProgressBar<T> {
         self.tick = tick_fmt
             .split("")
             .map(|x| x.to_owned())
-            .filter(|x| x != "")
+            .filter(|x| !x.is_empty())
             .collect();
     }
 


### PR DESCRIPTION
```
warning: comparison to empty slice
   --> src/multi.rs:249:23
    |
249 |                 done: s == "",
    |                       ^^^^^^^ help: using `is_empty` is clearer and more explicit: `s.is_empty()`
    |
    = note: `#[warn(clippy::comparison_to_empty)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#comparison_to_empty

warning: comparison to empty slice
   --> src/pb.rs:218:25
    |
218 |             .filter(|x| x != "")
    |                         ^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!x.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#comparison_to_empty
```