### PR TITLE
Fix clippy warnings: redundant field names in struct initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ where
     pub fn on(handle: T, iter: I) -> Self {
         let size = iter.size_hint().0;
         PbIter {
-            iter: iter,
+            iter,
             progress_bar: ProgressBar::on(handle, size as u64),
         }
     }

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -82,7 +82,7 @@ impl<T: Write> MultiBar<T> {
         MultiBar {
             state: Mutex::new(State {
                 lines: Vec::new(),
-                handle: handle,
+                handle,
                 nlines: 0,
             }),
             chan: unbounded(),

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -101,7 +101,7 @@ impl<T: Write> ProgressBar<T> {
     /// ```
     pub fn on(handle: T, total: u64) -> ProgressBar<T> {
         let mut pb = ProgressBar {
-            total: total,
+            total,
             current: 0,
             start_time: Instant::now(),
             units: Units::Default,
@@ -125,7 +125,7 @@ impl<T: Write> ProgressBar<T> {
             message: String::new(),
             last_refresh_time: Instant::now(),
             max_refresh_rate: None,
-            handle: handle,
+            handle,
         };
         pb.format(FORMAT);
         pb.tick_format(TICK_FORMAT);


### PR DESCRIPTION
Fix several warnings about redundant field names like the one below:

```
warning: redundant field names in struct initialization
  --> src/multi.rs:85:17
   |
85 |                 handle: handle,
   |                 ^^^^^^^^^^^^^^ help: replace it with: `handle`
   |
   = note: `#[warn(clippy::redundant_field_names)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
```