### PR TITLE
Fix clippy warnings: useless use of `format!`

### DIFF
--- a/src/pb.rs
+++ b/src/pb.rs
@@ -355,7 +355,7 @@ impl<T: Write> ProgressBar<T> {
         suffix += &parts.join(" ");
         // message box
         if self.show_message {
-            prefix = prefix + &format!("{}", self.message);
+            prefix = prefix + &self.message;
         }
         // counter box
         if self.show_counter {
@@ -437,7 +437,7 @@ impl<T: Write> ProgressBar<T> {
     pub fn finish_print(&mut self, s: &str) {
         self.finish_draw();
         let width = self.width();
-        let mut out = format!("{}", s);
+        let mut out = s.to_owned();
         if s.len() < width {
             out += &" ".repeat(width - s.len());
         };


### PR DESCRIPTION
```
warning: useless use of `format!`
   --> src/pb.rs:358:32
    |
358 |             prefix = prefix + &format!("{}", self.message);
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `self.message.to_string()`
    |
    = note: `#[warn(clippy::useless_format)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

warning: useless use of `format!`
   --> src/pb.rs:440:23
    |
440 |         let mut out = format!("{}", s);
    |                       ^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `s.to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format
```