### PR TITLE
Fix return value of `Write::write` impl for `Pipe`

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -251,7 +251,7 @@ impl Write for Pipe {
                 string: s,
             })
             .unwrap();
-        Ok(1)
+        Ok(buf.len())
     }
 
     fn flush(&mut self) -> Result<()> {

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -429,7 +429,7 @@ impl<T: Write> ProgressBar<T> {
     /// the last time
     pub fn finish(&mut self) {
         self.finish_draw();
-        printfl!(self.handle, "");
+        self.handle.write(b"").expect("write() failed");
     }
 
     /// Call finish and write string `s` that will replace the progress bar.


### PR DESCRIPTION
This should return the number of bytes written, which as implemented is the whole buffer.

Without this, the default `write_all` implementation won't work correctly, which is a problem with
c520a21acb3733036d77e273db09981ff8093df1.