### PR TITLE
Fine-tune the Ordering for nbars

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -160,7 +160,7 @@ impl<T: Write> MultiBar<T> {
         state.lines.push(String::new());
         state.nlines += 1;
 
-        self.nbars.fetch_add(1, Ordering::SeqCst);
+        self.nbars.fetch_add(1, Ordering::Release);
 
         let mut p = ProgressBar::on(
             Pipe {
@@ -207,11 +207,11 @@ impl<T: Write> MultiBar<T> {
         let mut first = true;
         let mut out = String::new();
 
-        while self.nbars.load(Ordering::SeqCst) > 0 {
+        while self.nbars.load(Ordering::Acquire) > 0 {
             // receive message
             let msg = self.chan.1.recv().unwrap();
             if msg.done {
-                self.nbars.fetch_sub(1, Ordering::SeqCst);
+                self.nbars.fetch_sub(1, Ordering::Relaxed);
                 continue;
             }
 


### PR DESCRIPTION
We still need `Release` here to make sure our write of `lines` and `nlines` happens before this, and we don't need `Acquire` here since there are no modifications we need to make visible to other thread.
https://github.com/a8m/pb/blob/d60b964be6a234c933fdf95d7b7851f383e21206/src/multi.rs#L160-L163
The `load` at 210 should use `Acquire` to synchronize with the store of `lines` and `nlines`, which are read at 220 and 224. The `CAS` operation at 214 can be `Relaxed` since, at this point, the `message` has done its job. Thus, this operation does not provide synchronization, only atomicity.
https://github.com/a8m/pb/blob/d60b964be6a234c933fdf95d7b7851f383e21206/src/multi.rs#L210-L234