### PR TITLE
Replaced `winapi` dependency with `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ license = "MIT"
 libc = "0.2"
 crossbeam-channel = "0.5"
 
-[target.'cfg(target_os = "windows")'.dependencies.winapi]
-version = "0.3"
-features = ["wincon", "processenv", "winbase"]
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.60"
+features = ["Win32_Foundation", "Win32_System_Console"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -17,7 +17,7 @@ pub fn terminal_size() -> Option<(Width, Height)> {
 /// move the cursor `n` lines up; return an empty string, just to
 /// be aligned with the unix version.
 pub fn move_cursor_up(n: usize) -> String {
-    use winapi::um::wincon::{SetConsoleCursorPosition, COORD};
+    use windows_sys::Win32::System::Console::{SetConsoleCursorPosition, COORD};
     if let Some((hand, csbi)) = get_csbi() {
         unsafe {
             SetConsoleCursorPosition(
@@ -33,14 +33,13 @@ pub fn move_cursor_up(n: usize) -> String {
 }
 
 fn get_csbi() -> Option<(
-    winapi::shared::ntdef::HANDLE,
-    winapi::um::wincon::CONSOLE_SCREEN_BUFFER_INFO,
+    windows_sys::Win32::Foundation::HANDLE,
+    windows_sys::Win32::System::Console::CONSOLE_SCREEN_BUFFER_INFO,
 )> {
-    use winapi::shared::ntdef::HANDLE;
-    use winapi::um::processenv::GetStdHandle;
-    use winapi::um::winbase::STD_OUTPUT_HANDLE;
-    use winapi::um::wincon::{
-        GetConsoleScreenBufferInfo, CONSOLE_SCREEN_BUFFER_INFO, COORD, SMALL_RECT,
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::System::Console::{
+        GetConsoleScreenBufferInfo, GetStdHandle, CONSOLE_SCREEN_BUFFER_INFO, COORD, SMALL_RECT,
+        STD_OUTPUT_HANDLE,
     };
 
     let hand: HANDLE = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };


### PR DESCRIPTION
The former has been considered superseded by the latter (retep998/winapi-rs#1055)